### PR TITLE
passing negative value to extract characters backwards in set method

### DIFF
--- a/jquery-textrange.js
+++ b/jquery-textrange.js
@@ -32,12 +32,15 @@
             start = 0;
             end = -1;
          }
+		 else if(start < 0) {
+			 start = parseInt(start) + this.val().length + 1;
+		 }
 
          if(typeof end === 'undefined') {
             end = start;
          }
-         else if(end === -1) {
-            end = this.val().length;
+         else if(end < 0) {
+            end = parseInt(end) + this.val().length + 1;
          }
 
          _textrange[browserType].set.apply(this, [start, end]);


### PR DESCRIPTION
Hello, when i try to cursor the end position, `$('input[name="example"]').textrange('set', -1);` could not run as it should be, so i add some lines. Now, i can extract characters from the end of the string using a negative number. 
Besides, I'm sorry to have `set` wiki page edited. i'm new here and have no idea to revert it yet. Apology :-P
