### PR TITLE
Update jquery-textrange.js

### DIFF
--- a/jquery-textrange.js
+++ b/jquery-textrange.js
@@ -159,7 +159,9 @@
 			},
 
 			set: function(start, end) {
-				this[0].focus();
+				if (document.activeElement !== this[0]) {
+					this[0].focus();
+				}
 
 				var range = this[0].createTextRange();
 
@@ -180,7 +182,9 @@
 			},
 
 			replace: function(text) {
-				this[0].focus();
+				if (document.activeElement !== this[0]) {
+					this[0].focus();
+				}
 
 				document.selection.createRange().text = text;
 			}

--- a/jquery-textrange.js
+++ b/jquery-textrange.js
@@ -127,7 +127,9 @@
 
 		msie: {
 			get: function(property) {
-				this[0].focus();
+				if (document.activeElement !== this[0]) {
+					this[0].focus();
+				}
 
 				var range = document.selection.createRange();
 


### PR DESCRIPTION
Call focus function of element in function 'get' for IE only, if it's not the active element yet.

Calling the focus function of the element every time you call the 'get' function causes a very unpleasant behaviour in IE8. You can reproduce it with the textarea of your [demo](http://dwieeb.github.com/jquery-textrange/). If you reduce the width of the browser until you see the textarea only partially and type one character after another, the content of the page will be scrolled automatically to the right at the moment you reach the right border of the page. But the call of the focus function causes the page to be scrolled to the left edge of the textarea. Immediately after that jump to the left side, the content is scrolled back to the cursor position, which leads to a flicker of the page every time you type a character.

Maybe it could be useful to only call the focus function in the other functions too.
