### PR TITLE
Update jquery-textrange.js

### DIFF
--- a/jquery-textrange.js
+++ b/jquery-textrange.js
@@ -6,6 +6,23 @@
  * (c) 2013 Daniel Imhoff <dwieeb@gmail.com> - danielimhoff.com
  */
 (function($) {
+    
+	/**
+	* Sets the focus to the specified element if it isn't focused yet.
+	* 
+	* Prevents unpleasant behaviour for textareas in IE:
+	* If you have a textarea which is too wide to be displayed entirely and therfore has to be scrolled horizontally,
+	* then typing one character after another will scroll the page automatically to the right at the moment you reach
+	* the right border of the visible part. But calling the focus function causes the page to be scrolled to the left
+	* edge of the textarea. Immediately after that jump to the left side, the content is scrolled back to the cursor
+	* position, which leads to a flicker page every time you type a character. 
+	*/
+	function focus(element) {
+		if (document.activeElement !== element) {
+			element.focus();
+		}
+	}
+    
 	var browserType,
 
 	textrange = {
@@ -98,7 +115,7 @@
 	_textrange = {
 		xul: {
 			get: function(property) {
-				this[0].focus();
+				focus(this[0]);
 				var props = {
 					position: this[0].selectionStart,
 					start: this[0].selectionStart,
@@ -111,13 +128,13 @@
 			},
 
 			set: function(start, end) {
-				this[0].focus();
+				focus(this[0]);
 				this[0].selectionStart = start;
 				this[0].selectionEnd = end;
 			},
 
 			replace: function(text) {
-				this[0].focus();
+				focus(this[0]);
 				var start = this[0].selectionStart;
 				this.val(this.val().substring(0, this[0].selectionStart) + text + this.val().substring(this[0].selectionEnd, this.val().length));
 				this[0].selectionStart = start;
@@ -127,10 +144,7 @@
 
 		msie: {
 			get: function(property) {
-				if (document.activeElement !== this[0]) {
-					this[0].focus();
-				}
-
+				focus(this[0]);
 				var range = document.selection.createRange();
 
 				if (typeof range === 'undefined') {
@@ -159,10 +173,7 @@
 			},
 
 			set: function(start, end) {
-				if (document.activeElement !== this[0]) {
-					this[0].focus();
-				}
-
+				focus(this[0]);
 				var range = this[0].createTextRange();
 
 				if (typeof range === 'undefined') {
@@ -182,10 +193,7 @@
 			},
 
 			replace: function(text) {
-				if (document.activeElement !== this[0]) {
-					this[0].focus();
-				}
-
+				focus(this[0]);
 				document.selection.createRange().text = text;
 			}
 		}


### PR DESCRIPTION
General use of focus function.

It has turned out that the issue with the textareas is also an issue for IE10, but for IE10 not the `msie` code block of **textrange** is used, but the `xul`. Therefore i added a `focus` function and use this in the entire code for focusing elements.
