### PR TITLE
added -nofocus variant of all methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,17 @@ $('input[name="example"]').textrange('setcursor', 5);
 
 ### 'replace'
 
-You can use this method to replace the selection with given text. 
+You can use this method to replace the selection with given text.
 
 ```javascript
 $('input[name="example"]').textrange('replace', 'some text');
 ```
 
 There is also an `insert` alias for `replace` if you're using this method to insert text at the cursor location. They work the same way.
+
+### 'get-nofocus', 'set-nofocus', 'setcursor-nofocus', 'replace-nofocus', 'insert-nofocus'
+
+You can add the suffix '-nofocus' to any of the method names to perform the corresponding operation without setting focus on the target element.
 
 ## Minified Version
 A minified version of this plugin can be generated using UglifyJS during your build process or via CLI tools:

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-textrange",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "main": "jquery-textrange.js",
   "dependencies": {
     "jquery": ">=1.3"

--- a/jquery-textrange.js
+++ b/jquery-textrange.js
@@ -230,8 +230,11 @@
 			return this;
 		}
 
-		// Focus on the element before operating upon it.
-		if (document.activeElement !== this[0]) {
+		// Focus on the element before operating upon it,
+		// unless the specified method ends in '-nofocus'
+		if (method.slice(-8)==='-nofocus') {
+			method = method.slice(0,-8); //strip the -nofocus suffix and bypass focus()
+		} else if (document.activeElement !== this[0]) {
 			this[0].focus();
 		}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-textrange",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "A jQuery plugin for getting, setting and replacing the selected text in input fields and textareas.",
   "main": "jquery-textrange.js",
   "dependencies": {

--- a/textrange.jquery.json
+++ b/textrange.jquery.json
@@ -18,7 +18,7 @@
     "substring",
     "substr"
   ],
-  "version": "1.3.3",
+  "version": "1.3.4",
   "author": {
     "name": "Daniel Imhoff",
     "email": "dwieeb@gmail.com",


### PR DESCRIPTION
I needed to manipulate text selections without setting focus on the text element, and this seemed the best solution for adding that variant while remaining fully backward compatible.
Please consider merging this addition into the main package or implementing this feature by other means.  Thanks!
